### PR TITLE
CI: Add deployment workflow for Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
 
   deploy:
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+
     environment: Develop
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -35,4 +35,4 @@ jobs:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Deploy to the server
       run: |
-        ssh -o StrictHostKeyChecking=no -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd brazil-blog && git pull && docker-compose up -d --build"
+        ssh -o StrictHostKeyChecking=no -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd brazil-blog && git pull && docker compose up -d --build"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,3 +16,20 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    # if: github.ref == 'refs/heads/main' # Uncomment this line if you want to deploy only from the main branch
+
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Deploy using SSH
+      uses: webfactory/ssh-agent@v0.5.3
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      run: |
+        ssh -o StrictHostKeyChecking=no -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd brazil-blog && git pull && docker-compose up -d --build"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,6 +19,8 @@ jobs:
 
   deploy:
 
+    environment: Develop
+
     runs-on: ubuntu-latest
 
     # if: github.ref == 'refs/heads/main' # Uncomment this line if you want to deploy only from the main branch

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,9 +27,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Deploy using SSH
+    - name: Setup SSH
       uses: webfactory/ssh-agent@v0.5.3
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+    - name: Deploy to the server
       run: |
         ssh -o StrictHostKeyChecking=no -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd brazil-blog && git pull && docker-compose up -d --build"


### PR DESCRIPTION
This pull request adds a deployment workflow for a Docker image. The workflow builds the Docker image and deploys it using SSH to a specified host. The deployment process includes pulling the latest changes from the repository and running the Docker image using docker-compose.