### PR TITLE
fix: Show avatar of page's user, not the current (not) logged in user.

### DIFF
--- a/src/blog/templates/blog/author_page.html
+++ b/src/blog/templates/blog/author_page.html
@@ -8,7 +8,7 @@
         
         <div class="flex flex-row gap-4 items-center">
             <div>
-                {% user_avatar user %}
+                {% user_avatar page.user %}
             </div>
             <div class="bio text-gray-700">
                 {{ page.bio|richtext }}


### PR DESCRIPTION
Resolves #60