### PR TITLE
Added: Show amount of comments per blog post on blog overview page

### DIFF
--- a/src/blog/templates/blog/includes/blogpost-grid.html
+++ b/src/blog/templates/blog/includes/blogpost-grid.html
@@ -21,6 +21,8 @@
                             <div class="flex items-center space-x-1 ml-auto bg-white rounded-full px-1">
                                 <span class="text-xl">😻</span>
                                 <span class="font-bold pr-1 mt-0.5">{{ post.specific.like_count }}</span>
+                                <span class="text-xl">💬</span>
+                                <span class="font-bold pr-1">{{ post.specific.comments.count }}</span>
                             </div>
                         </div>
                         <div>


### PR DESCRIPTION
This pull request adds a feature to display the number of comments per blog post on the blog overview page. The changes include adding a new section to the post template that shows the comment count and updating the CSS styles to accommodate the new section.

![afbeelding](https://github.com/user-attachments/assets/fce03637-3e6c-4b7f-970e-de0a812ab34c)
