### PR TITLE
Add django-crontab for scheduled tasks and update settings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ ruff
 
 # markdown for markdown support
 django-markup
+
+# django crontab for cron jobs
+django-crontab

--- a/src/brazil_blog/settings/base.py
+++ b/src/brazil_blog/settings/base.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "django_markup",
+    "django_crontab",
 ]
 
 MIDDLEWARE = [
@@ -213,3 +214,8 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 
 # enable TLS by default
 EMAIL_USE_TLS = True
+
+# Crontab settings
+CRONJOBS = [
+    ("0 1 * * *", "django.core.management.call_command", ["senddailydigest"]),
+]


### PR DESCRIPTION
This PR introduces the `django-crontab` package to manage scheduled tasks within the Django application. The settings have been updated to include `django-crontab` in the installed apps and to define a cron job for sending daily digests at 1 AM. This enhancement streamlines task scheduling and improves application functionality.