### PR TITLE
fix: replace StrictHostKeyChecking=no with ssh-keyscan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Add server to known hosts
+        run: ssh-keyscan -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
       - name: Deploy to the server
         env:
           DJANGO_SUPERUSER_USERNAME: ${{ secrets.DJANGO_SUPERUSER_USERNAME }}
@@ -63,7 +65,7 @@ jobs:
           EMAIL_HOST: ${{ secrets.EMAIL_HOST }}
           EMAIL_PORT: ${{ secrets.EMAIL_PORT }}
         run: |
-          ssh -o StrictHostKeyChecking=no -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+          ssh -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
           "export DJANGO_SUPERUSER_USERNAME='$DJANGO_SUPERUSER_USERNAME' && \
           export DJANGO_SUPERUSER_PASSWORD='$DJANGO_SUPERUSER_PASSWORD' && \
           export DJANGO_SUPERUSER_EMAIL='$DJANGO_SUPERUSER_EMAIL' && \
@@ -77,7 +79,7 @@ jobs:
           docker system prune -f"
       - name: Clear cache
         run: |
-          ssh -o StrictHostKeyChecking=no -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd brazil-blog && bin/manage clearcache"
+          ssh -p ${{ secrets.SSH_PORT }} ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "cd brazil-blog && bin/manage clearcache"
   
 
   smoketests:


### PR DESCRIPTION
## Summary

- Adds an `ssh-keyscan` step to populate `~/.ssh/known_hosts` before SSH commands run
- Removes `-o StrictHostKeyChecking=no` from both the deploy and clear-cache steps

## Why

`StrictHostKeyChecking=no` disables SSH host key verification, making the deployment vulnerable to man-in-the-middle attacks. If the server's fingerprint changes unexpectedly, SSH will silently connect anyway instead of aborting.

Using `ssh-keyscan` upfront captures the server's fingerprint at deploy time and stores it in `known_hosts`, so SSH can verify the host identity normally on subsequent connections.

Fixes the "raw" code review comment on commit 049f0821.